### PR TITLE
Allow overriding colors in the 256 color space

### DIFF
--- a/src/st.c
+++ b/src/st.c
@@ -3445,7 +3445,7 @@ xloadcolor(int i, const char *name, Color *ncolor)
 	XRenderColor color = { .alpha = 0xffff };
 
 	if (!name) {
-		if (BETWEEN(i, 16, 255)) { /* 256 color */
+		if (!colorname[i] && BETWEEN(i, 16, 255)) { /* 256 color */
 			if (i < 6*6*6+16) { /* same colors as xterm */
 				color.red   = sixd_to_16bit( ((i-16)/36)%6 );
 				color.green = sixd_to_16bit( ((i-16)/6) %6 );


### PR DESCRIPTION
Simple change that allows user-defined colors for the range 16-255. Reloading a config with less colors (e.g. going from 21 to just basic 16) seems to work fine as well - the now undefined colors revert to their defaults, just as expected.