### PR TITLE
Created an RPM for xst

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-﻿:pill: xst :pill:
+ :pill: xst :pill:
 
 `xst` is an [in progress](https://github.com/neeasade/xst/blob/master/doc/TODO.md) [st](http://st.suckless.org) fork that:
 
 - Loads settings from Xresources. See https://git.io/vVisW
 - Live-reloads settings from xrdb on USR1 signal (like termite)
 - Is available as an AUR package `xst-git` (binary and man also still named st)
+- Is available as a copr package for Fedora`keefle/xst` (binary and man also still named st)
 - Has cursor blinking options
 - Has the following [st-patches](http://st.suckless.org/patches/) applied:
     - spoiler


### PR DESCRIPTION
Now xst is available as a Fedora copr package.

Installation:
```bash
sudo dnf copr enable keefle/xst
sudo dnf install xst
```