### PR TITLE
Add ALT Linux to the list of distributions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - vertcenter
     - alpha (transparent background)
 - Available in packages:
+    - ALT Linux (Sisyphus): `xst`
     - Arch Linux (AUR): `xst-git`
     - Fedora (COPR): `keefle/xst`
     - Gentoo (personal overlay): https://framagit.org/3/ebuilds


### PR DESCRIPTION
This adds ALT Linux to the list of distributions, containting xsd. Package is published by me - https://packages.altlinux.org/en/sisyphus/srpms/xst