### PR TITLE
Update FAQ

### DIFF
--- a/doc/FAQ
+++ b/doc/FAQ
@@ -6,7 +6,7 @@ Use the excellent tool of [utmp](http://git.suckless.org/utmp/) for this task.
 
 It means that st doesn’t have any terminfo entry on your system. Chances are
 you did not `make install`. If you just want to test it without installing it,
-you can manualy run `tic -s st.info`.
+you can manually run `tic -s xst.info`.
 
 ## Nothing works, and nothing is said about an unknown terminal!
 


### PR DESCRIPTION
- Fixing minor typo
- Ensuring the file name for the `tic` command is correct (`xst.info`)