### PR TITLE
fix(makefile): honor DESTDIR and PREFIX for tic (terminfo generation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,18 @@ install: st
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	sed "s/VERSION/$(VERSION)/g" < st.1 > $(DESTDIR)$(MANPREFIX)/man1/xst.1
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/xst.1
-	tic -sx st.info
-	@echo Please see the README file regarding the terminfo entry of st.
+	mkdir -p $(DESTDIR)$(PREFIX)/share/terminfo
+	env TERMINFO=$(DESTDIR)$(PREFIX)/share/terminfo tic -sx st.info
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/xst
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/xst.1
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-256color
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-bs
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-bs-256color
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-meta
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-meta-256color
+	rm -f $(DESTDIR)$(PREFIX)/share/terminfo/x/xst-mono
 
 .PHONY: all options clean dist install uninstall


### PR DESCRIPTION
fixes #78

```console
$ make PREFIX=/usr DESTDIR=./pkgdir/ install
<...>

$ tree -a pkgdir/
pkgdir/
└── usr
    ├── bin
    │   └── xst
    └── share
        ├── man
        │   └── man1
        │       └── xst.1
        └── terminfo
            └── x
                ├── xst
                ├── xst-256color
                ├── xst-bs
                ├── xst-bs-256color
                ├── xst-meta
                ├── xst-meta-256color
                └── xst-mono
```