### PR TITLE
Xresources's scrollrate messes with internal kscrollup/down calls

### DIFF
--- a/st.c
+++ b/st.c
@@ -1078,7 +1078,7 @@ kscrolldown(const Arg* a)
 {
 	int n = a->i;
 
-	if (scrollrate)
+	if (scrollrate && (n==1))
 		n = scrollrate;
 
 	if (n < 0)
@@ -1099,7 +1099,7 @@ kscrollup(const Arg* a)
 {
 	int n = a->i;
 
-	if (scrollrate)
+	if (scrollrate && (n==1))
 		n = scrollrate;
 
 	if (n < 0)


### PR DESCRIPTION
Anyway whenever kscrollup/down is called in the code, the scroll movement always gets limited to the value set by ``st.scrollrate set`` in the Xresources file. 
That means fxp. whenever I try to scroll up, but I need to type something out, the terminal moves down by ``st.scrollrate`` instead of just jumping down to the last line, like it regularly would.

NOTE: This patch considers that no one changed the default Arg.i = 1 in the config.h file and instead fixes the issue for users that use Xresources values, since in that case the kscrollup/down functions will get always called with Arg.i set to 1.