### PR TITLE
undercurls (fixes #136)

### DIFF
--- a/.Xresources
+++ b/.Xresources
@@ -89,6 +89,8 @@ st.disable_alpha_correction: 0
 ! / \   / \   / \
 !    \_/   \_/
 st.undercurl_shape: 1
+! adds 1 pixel of thickness to the undercurl for every undercurl_thickness_threshold pixels of font size
+st.undercurl_thickness_threshold: 28
 
 ! colors -- this is the base16-twilight colorscheme.
 st.foreground:   #a7a7a7

--- a/.Xresources
+++ b/.Xresources
@@ -73,6 +73,23 @@ st.opacity:      255
 ! without the composition)
 st.disable_alpha_correction: 0
 
+! undercurl style. either 1, 2 or 3 (0 disables)
+!
+! 0: Curly
+!  _   _   _   _
+! ( ) ( ) ( ) ( )
+!	(_) (_) (_) (_)
+!
+! 1: Spiky
+! /\  /\  /\  /\
+!   \/  \/	\/
+!
+! 2: Capped
+!  _     _     _
+! / \   / \   / \
+!    \_/   \_/
+st.undercurl_shape: 1
+
 ! colors -- this is the base16-twilight colorscheme.
 st.foreground:   #a7a7a7
 st.background:   #1e1e1e

--- a/config.def.h
+++ b/config.def.h
@@ -537,3 +537,4 @@ static char ascii_printable[] =
  * render method of undercurls
  */
 static unsigned int undercurl_shape = 1;
+static unsigned int undercurl_thickness_threshold = 28;

--- a/config.def.h
+++ b/config.def.h
@@ -532,10 +532,3 @@ static char ascii_printable[] =
 	" !\"#$%&'()*+,-./0123456789:;<=>?"
 	"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
 	"`abcdefghijklmnopqrstuvwxyz{|}~";
-
-// Undercurls
-#define UNDERCURL_CURLY 0
-#define UNDERCURL_SPIKY 1
-#define UNDERCURL_CAPPED 2
-
-#define UNDERCURL_STYLE UNDERCURL_SPIKY

--- a/config.def.h
+++ b/config.def.h
@@ -532,3 +532,10 @@ static char ascii_printable[] =
 	" !\"#$%&'()*+,-./0123456789:;<=>?"
 	"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
 	"`abcdefghijklmnopqrstuvwxyz{|}~";
+
+// Undercurls
+#define UNDERCURL_CURLY 0
+#define UNDERCURL_SPIKY 1
+#define UNDERCURL_CAPPED 2
+
+#define UNDERCURL_STYLE UNDERCURL_SPIKY

--- a/config.def.h
+++ b/config.def.h
@@ -532,3 +532,8 @@ static char ascii_printable[] =
 	" !\"#$%&'()*+,-./0123456789:;<=>?"
 	"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
 	"`abcdefghijklmnopqrstuvwxyz{|}~";
+
+/*
+ * render method of undercurls
+ */
+static unsigned int undercurl_shape = 1;

--- a/st.c
+++ b/st.c
@@ -33,6 +33,7 @@
 #define UTF_SIZ       4
 #define ESC_BUF_SIZ   (128*UTF_SIZ)
 #define ESC_ARG_SIZ   16
+#define CAR_PER_ARG   4
 #define STR_BUF_SIZ   ESC_BUF_SIZ
 #define STR_ARG_SIZ   ESC_ARG_SIZ
 #define HISTSIZE      2000
@@ -146,6 +147,7 @@ typedef struct {
 	int arg[ESC_ARG_SIZ];
 	int narg;              /* nb of args */
 	char mode[2];
+    int carg[ESC_ARG_SIZ][CAR_PER_ARG]; /* colon args */
 } CSIEscape;
 
 /* STR Escape sequence structs */
@@ -167,6 +169,7 @@ static void ttywriteraw(const char *, size_t);
 static void csidump(void);
 static void csihandle(void);
 static void csiparse(void);
+static void readcolonargs(char **, int, int[][CAR_PER_ARG]);
 static void csireset(void);
 static int eschandle(uchar);
 static void strdump(void);
@@ -1205,6 +1208,28 @@ tnewline(int first_col)
 }
 
 void
+readcolonargs(char **p, int cursor, int params[][CAR_PER_ARG])
+{
+	int i = 0;
+	for (; i < CAR_PER_ARG; i++)
+		params[cursor][i] = -1;
+
+	if (**p != ':')
+		return;
+
+	char *np = NULL;
+	i = 0;
+
+	while (**p == ':' && i < CAR_PER_ARG) {
+		while (**p == ':')
+			(*p)++;
+		params[cursor][i] = strtol(*p, &np, 10);
+		*p = np;
+		i++;
+	}
+}
+
+void
 csiparse(void)
 {
 	char *p = csiescseq.buf, *np;
@@ -1226,6 +1251,7 @@ csiparse(void)
 			v = -1;
 		csiescseq.arg[csiescseq.narg++] = v;
 		p = np;
+        readcolonargs(&p, csiescseq.narg-1, csiescseq.carg);
 		if (*p != ';' || csiescseq.narg == ESC_ARG_SIZ)
 			break;
 		p++;
@@ -1445,6 +1471,10 @@ tsetattr(int *attr, int l)
 				ATTR_STRUCK     );
 			term.c.attr.fg = defaultfg;
 			term.c.attr.bg = defaultbg;
+ 			term.c.attr.ustyle = -1;
+ 			term.c.attr.ucolor[0] = -1;
+ 			term.c.attr.ucolor[1] = -1;
+ 			term.c.attr.ucolor[2] = -1;
 			break;
 		case 1:
 			term.c.attr.mode |= ATTR_BOLD;
@@ -1456,7 +1486,14 @@ tsetattr(int *attr, int l)
 			term.c.attr.mode |= ATTR_ITALIC;
 			break;
 		case 4:
-			term.c.attr.mode |= ATTR_UNDERLINE;
+ 			term.c.attr.ustyle = csiescseq.carg[i][0];
+ 
+ 			if (term.c.attr.ustyle != 0)
+ 				term.c.attr.mode |= ATTR_UNDERLINE;
+ 			else
+ 				term.c.attr.mode &= ~ATTR_UNDERLINE;
+ 
+ 			term.c.attr.mode ^= ATTR_DIRTYUNDERLINE;
 			break;
 		case 5: /* slow blink */
 			/* FALLTHROUGH */
@@ -1507,6 +1544,18 @@ tsetattr(int *attr, int l)
 		case 49:
 			term.c.attr.bg = defaultbg;
 			break;
+ 		case 58:
+ 			term.c.attr.ucolor[0] = csiescseq.carg[i][1];
+ 			term.c.attr.ucolor[1] = csiescseq.carg[i][2];
+ 			term.c.attr.ucolor[2] = csiescseq.carg[i][3];
+ 			term.c.attr.mode ^= ATTR_DIRTYUNDERLINE;
+ 			break;
+ 		case 59:
+ 			term.c.attr.ucolor[0] = -1;
+ 			term.c.attr.ucolor[1] = -1;
+ 			term.c.attr.ucolor[2] = -1;
+ 			term.c.attr.mode ^= ATTR_DIRTYUNDERLINE;
+ 			break;
 		default:
 			if (BETWEEN(attr[i], 30, 37)) {
 				term.c.attr.fg = attr[i] - 30;

--- a/st.c
+++ b/st.c
@@ -147,7 +147,7 @@ typedef struct {
 	int arg[ESC_ARG_SIZ];
 	int narg;              /* nb of args */
 	char mode[2];
-    int carg[ESC_ARG_SIZ][CAR_PER_ARG]; /* colon args */
+	int carg[ESC_ARG_SIZ][CAR_PER_ARG]; /* colon args */
 } CSIEscape;
 
 /* STR Escape sequence structs */
@@ -1251,7 +1251,7 @@ csiparse(void)
 			v = -1;
 		csiescseq.arg[csiescseq.narg++] = v;
 		p = np;
-        readcolonargs(&p, csiescseq.narg-1, csiescseq.carg);
+		readcolonargs(&p, csiescseq.narg-1, csiescseq.carg);
 		if (*p != ';' || csiescseq.narg == ESC_ARG_SIZ)
 			break;
 		p++;

--- a/st.h
+++ b/st.h
@@ -35,6 +35,7 @@ enum glyph_attribute {
 	ATTR_WDUMMY     = 1 << 10,
 	ATTR_BOXDRAW    = 1 << 11,
 	ATTR_BOLD_FAINT = ATTR_BOLD | ATTR_FAINT,
+ 	ATTR_DIRTYUNDERLINE = 1 << 15,
 };
 
 enum selection_mode {
@@ -66,6 +67,8 @@ typedef struct {
 	ushort mode;      /* attribute flags */
 	uint32_t fg;      /* foreground  */
 	uint32_t bg;      /* background  */
+    int ustyle;	      /* underline style */
+    int ucolor[3];    /* underline color */
 } Glyph;
 
 typedef Glyph *Line;

--- a/st.h
+++ b/st.h
@@ -67,8 +67,8 @@ typedef struct {
 	ushort mode;      /* attribute flags */
 	uint32_t fg;      /* foreground  */
 	uint32_t bg;      /* background  */
-    int ustyle;	      /* underline style */
-    int ucolor[3];    /* underline color */
+ 	int ustyle;       /* underline style */
+ 	int ucolor[3];    /* underline color */
 } Glyph;
 
 typedef Glyph *Line;

--- a/st.info
+++ b/st.info
@@ -1,5 +1,5 @@
 xst-mono| simpleterm monocolor,
-    Su,
+ 	Su,
 	acsc=+C\,D-A.B0E``aaffgghFiGjjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~,
 	am,
 	bce,

--- a/st.info
+++ b/st.info
@@ -1,4 +1,5 @@
 xst-mono| simpleterm monocolor,
+    Su,
 	acsc=+C\,D-A.B0E``aaffgghFiGjjkkllmmnnooppqqrrssttuuvvwwxxyyzz{{||}}~~,
 	am,
 	bce,

--- a/x.c
+++ b/x.c
@@ -1761,7 +1761,7 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
             int ww = win.cw;//width;
             int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
             int wx = winx;
-            int wy = winy + win.ch - dc.font.descent;
+            int wy = winy + win.cyo + win.ch - dc.font.descent;
 
             // Cap is half of wave width
             float capRatio = 0.5f;

--- a/x.c
+++ b/x.c
@@ -1595,7 +1595,7 @@ drawundercurlcurly(GC ugc, int winx, int winy, int wlw, int width, int widthThre
 	int ww = win.cw;//width;
 	int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
 	int wx = winx;
-	int wy = winy + win.cyo + win.ch - dc.font.descent;
+	int wy = winy + win.ch - dc.font.descent + win.cyo;
 	// Draw waves
 	int narcs = charlen * 2 + 1;
 	XArc *arcs = xmalloc(sizeof(XArc) * narcs);
@@ -1641,7 +1641,7 @@ drawundercurlspiky(GC ugc, int winx, int winy, int wlw, int width, int widthThre
 	int ww = win.cw;//width;
 	int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
 	int wx = winx;
-	int wy = winy + win.ch - dc.font.descent;
+	int wy = winy + win.ch - dc.font.descent + win.cyo;
 	// Make the underline corridor larger
 	/*
 	wy -= wh;
@@ -1750,7 +1750,7 @@ drawundercurlcapped(GC ugc, int winx, int winy, int wlw, int width, int widthThr
 	int ww = win.cw;//width;
 	int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
 	int wx = winx;
-	int wy = winy + win.cyo + win.ch - dc.font.descent;
+	int wy = winy + win.cyo + win.ch - dc.font.descent + win.cyo;
 
 	// Cap is half of wave width
 	float capRatio = 0.5f;
@@ -2071,7 +2071,7 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 			XftDrawRect(xw.draw, fg, winx, winy + win.cyo + dc.font.ascent + 1, width, 1);
 		// Undercurl
 		} else if (base.ustyle == 3) {
-			const int widthThreshold = 28;				// +1 width every widthThreshold px of font
+			const int widthThreshold = undercurl_thickness_threshold;				// +1 width every widthThreshold px of font
 			int wlw = (win.ch / widthThreshold) + 1;	// Wave Line Width
 			XGCValues ugcv = {
 				.foreground = selectlinecolor(base, fg),

--- a/x.c
+++ b/x.c
@@ -2081,9 +2081,20 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 			};
 
 			GC ugc = XCreateGC(xw.dpy, XftDrawDrawable(xw.draw), GCForeground | GCLineWidth | GCLineStyle | GCCapStyle, &ugcv);
-			// drawundercurlcurly(ugc, winx, winy, wlw, width, widthThreshold, charlen);
-			// drawundercurlspiky(ugc, winx, winy, wlw, width, widthThreshold);
-			drawundercurlcapped(ugc, winx, winy, wlw, width, widthThreshold);
+            
+            switch (undercurl_shape) {
+                case 1:
+                    drawundercurlcurly(ugc, winx, winy, wlw, width, widthThreshold, charlen);
+                    break;
+                case 2:
+                    drawundercurlspiky(ugc, winx, winy, wlw, width, widthThreshold);
+                    break;
+                case 3:
+                    drawundercurlcapped(ugc, winx, winy, wlw, width, widthThreshold);
+                    break;
+                default: ;
+            }
+
 			XFreeGC(xw.dpy, ugc);
 		}
 	}

--- a/x.c
+++ b/x.c
@@ -47,6 +47,14 @@ typedef struct {
 	signed char appcursor; /* application cursor */
 } Key;
 
+/* Undercurl slope types */
+enum undercurl_slope_type {
+	UNDERCURL_SLOPE_ASCENDING = 0,
+	UNDERCURL_SLOPE_TOP_CAP = 1,
+	UNDERCURL_SLOPE_DESCENDING = 2,
+	UNDERCURL_SLOPE_BOTTOM_CAP = 3
+};
+
 /* X modifiers */
 #define XK_ANY_MOD    UINT_MAX
 #define XK_NO_MOD     0
@@ -1534,6 +1542,51 @@ xmakeglyphfontspecs(XftGlyphFontSpec *specs, const Glyph *glyphs, int len, int x
 	return numspecs;
 }
 
+static int isSlopeRising (int x, int iPoint, int waveWidth)
+{
+	//    .     .     .     .
+	//   / \   / \   / \   / \
+	//  /   \ /   \ /   \ /   \
+	// .     .     .     .     .
+
+	// Find absolute `x` of point
+	x += iPoint * (waveWidth/2);
+
+	// Find index of absolute wave
+	int absSlope = x / ((float)waveWidth/2);
+
+	return (absSlope % 2);
+}
+
+static int getSlope (int x, int iPoint, int waveWidth)
+{
+	// Sizes: Caps are half width of slopes
+	//    1_2       1_2       1_2      1_2
+	//   /   \     /   \     /   \    /   \
+	//  /     \   /     \   /     \  /     \
+	// 0       3_0       3_0      3_0       3_
+	// <2->    <1>         <---6---->
+
+	// Find type of first point
+	int firstType;
+	x -= (x / waveWidth) * waveWidth;
+	if (x < (waveWidth * (2.f/6.f)))
+		firstType = UNDERCURL_SLOPE_ASCENDING;
+	else if (x < (waveWidth * (3.f/6.f)))
+		firstType = UNDERCURL_SLOPE_TOP_CAP;
+	else if (x < (waveWidth * (5.f/6.f)))
+		firstType = UNDERCURL_SLOPE_DESCENDING;
+	else
+		firstType = UNDERCURL_SLOPE_BOTTOM_CAP;
+
+	// Find type of given point
+	int pointType = (iPoint % 4);
+	pointType += firstType;
+	pointType %= 4;
+
+	return pointType;
+}
+
 void
 xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, int y)
 {
@@ -1665,8 +1718,357 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 
 	/* Render underline and strikethrough. */
 	if (base.mode & ATTR_UNDERLINE) {
-		XftDrawRect(xw.draw, fg, winx, winy + win.cyo + dc.font.ascent + 1,
- 				width, 1);
+		// Underline Color
+		const int widthThreshold  = 28; // +1 width every widthThreshold px of font
+		int wlw = (win.ch / widthThreshold) + 1; // Wave Line Width
+		int linecolor;
+		if ((base.ucolor[0] >= 0) &&
+			!(base.mode & ATTR_BLINK && win.mode & MODE_BLINK) &&
+			!(base.mode & ATTR_INVISIBLE)
+		) {
+			// Special color for underline
+			// Index
+			if (base.ucolor[1] < 0) {
+				linecolor = dc.col[base.ucolor[0]].pixel;
+			}
+			// RGB
+			else {
+				XColor lcolor;
+				lcolor.red = base.ucolor[0] * 257;
+				lcolor.green = base.ucolor[1] * 257;
+				lcolor.blue = base.ucolor[2] * 257;
+				lcolor.flags = DoRed | DoGreen | DoBlue;
+				XAllocColor(xw.dpy, xw.cmap, &lcolor);
+				linecolor = lcolor.pixel;
+			}
+		} else {
+			// Foreground color for underline
+			linecolor = fg->pixel;
+		}
+
+		XGCValues ugcv = {
+			.foreground = linecolor,
+			.line_width = wlw,
+			.line_style = LineSolid,
+			.cap_style = CapNotLast
+		};
+
+		GC ugc = XCreateGC(xw.dpy, XftDrawDrawable(xw.draw),
+			GCForeground | GCLineWidth | GCLineStyle | GCCapStyle,
+			&ugcv);
+
+		// Underline Style
+		if (base.ustyle != 3) {
+			//XftDrawRect(xw.draw, fg, winx, winy + dc.font.ascent + 1, width, 1);
+			XFillRectangle(xw.dpy, XftDrawDrawable(xw.draw), ugc, winx,
+				winy + dc.font.ascent + 1, width, wlw);
+		} else if (base.ustyle == 3) {
+			int ww = win.cw;//width;
+			int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
+			int wx = winx;
+			int wy = winy + win.ch - dc.font.descent;
+
+#if UNDERCURL_STYLE == UNDERCURL_CURLY
+			// Draw waves
+			int narcs = charlen * 2 + 1;
+			XArc *arcs = xmalloc(sizeof(XArc) * narcs);
+
+			int i = 0;
+			for (i = 0; i < charlen-1; i++) {
+				arcs[i*2] = (XArc) {
+					.x = wx + win.cw * i + ww / 4,
+					.y = wy,
+					.width = win.cw / 2,
+					.height = wh,
+					.angle1 = 0,
+					.angle2 = 180 * 64
+				};
+				arcs[i*2+1] = (XArc) {
+					.x = wx + win.cw * i + ww * 0.75,
+					.y = wy,
+					.width = win.cw/2,
+					.height = wh,
+					.angle1 = 180 * 64,
+					.angle2 = 180 * 64
+				};
+			}
+			// Last wave
+			arcs[i*2] = (XArc) {wx + ww * i + ww / 4, wy, ww / 2, wh,
+			0, 180 * 64 };
+			// Last wave tail
+			arcs[i*2+1] = (XArc) {wx + ww * i + ww * 0.75, wy, ceil(ww / 2.),
+			wh, 180 * 64, 90 * 64};
+			// First wave tail
+			i++;
+			arcs[i*2] = (XArc) {wx - ww/4 - 1, wy, ceil(ww / 2.), wh, 270 * 64,
+			90 * 64 };
+
+			XDrawArcs(xw.dpy, XftDrawDrawable(xw.draw), ugc, arcs, narcs);
+
+			free(arcs);
+#elif UNDERCURL_STYLE == UNDERCURL_SPIKY
+			// Make the underline corridor larger
+			/*
+			wy -= wh;
+			*/
+			wh *= 2;
+
+			// Set the angle of the slope to 45°
+			ww = wh;
+
+			// Position of wave is independent of word, it's absolute
+			wx = (wx / (ww/2)) * (ww/2);
+
+			int marginStart = winx - wx;
+
+			// Calculate number of points with floating precision
+			float n = width;					// Width of word in pixels
+			n = (n / ww) * 2;					// Number of slopes (/ or \)
+			n += 2;								// Add two last points
+			int npoints = n;					// Convert to int
+
+			// Total length of underline
+			float waveLength = 0;
+
+			if (npoints >= 3) {
+				// We add an aditional slot in case we use a bonus point
+				XPoint *points = xmalloc(sizeof(XPoint) * (npoints + 1));
+
+				// First point (Starts with the word bounds)
+				points[0] = (XPoint) {
+					.x = wx + marginStart,
+					.y = (isSlopeRising(wx, 0, ww))
+						? (wy - marginStart + ww/2.f)
+						: (wy + marginStart)
+				};
+
+				// Second point (Goes back to the absolute point coordinates)
+				points[1] = (XPoint) {
+					.x = (ww/2.f) - marginStart,
+					.y = (isSlopeRising(wx, 1, ww))
+						? (ww/2.f - marginStart)
+						: (-ww/2.f + marginStart)
+				};
+				waveLength += (ww/2.f) - marginStart;
+
+				// The rest of the points
+				for (int i = 2; i < npoints-1; i++) {
+					points[i] = (XPoint) {
+						.x = ww/2,
+						.y = (isSlopeRising(wx, i, ww))
+							? wh/2
+							: -wh/2
+					};
+					waveLength += ww/2;
+				}
+
+				// Last point
+				points[npoints-1] = (XPoint) {
+					.x = ww/2,
+					.y = (isSlopeRising(wx, npoints-1, ww))
+						? wh/2
+						: -wh/2
+				};
+				waveLength += ww/2;
+
+				// End
+				if (waveLength < width) { // Add a bonus point?
+					int marginEnd = width - waveLength;
+					points[npoints] = (XPoint) {
+						.x = marginEnd,
+						.y = (isSlopeRising(wx, npoints, ww))
+							? (marginEnd)
+							: (-marginEnd)
+					};
+
+					npoints++;
+				} else if (waveLength > width) { // Is last point too far?
+					int marginEnd = waveLength - width;
+					points[npoints-1].x -= marginEnd;
+					if (isSlopeRising(wx, npoints-1, ww))
+						points[npoints-1].y -= (marginEnd);
+					else
+						points[npoints-1].y += (marginEnd);
+				}
+
+				// Draw the lines
+				XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points, npoints,
+						CoordModePrevious);
+
+				// Draw a second underline with an offset of 1 pixel
+				if ( ((win.ch / (widthThreshold/2)) % 2)) {
+					points[0].x++;
+
+					XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points,
+							npoints, CoordModePrevious);
+				}
+
+				// Free resources
+				free(points);
+			}
+#else // UNDERCURL_CAPPED
+			// Cap is half of wave width
+			float capRatio = 0.5f;
+
+			// Make the underline corridor larger
+			wh *= 2;
+
+			// Set the angle of the slope to 45°
+			ww = wh;
+			ww *= 1 + capRatio; // Add a bit of width for the cap
+
+			// Position of wave is independent of word, it's absolute
+			wx = (wx / ww) * ww;
+
+			float marginStart;
+			switch(getSlope(winx, 0, ww)) {
+				case UNDERCURL_SLOPE_ASCENDING:
+					marginStart = winx - wx;
+					break;
+				case UNDERCURL_SLOPE_TOP_CAP:
+					marginStart = winx - (wx + (ww * (2.f/6.f)));
+					break;
+				case UNDERCURL_SLOPE_DESCENDING:
+					marginStart = winx - (wx + (ww * (3.f/6.f)));
+					break;
+				case UNDERCURL_SLOPE_BOTTOM_CAP:
+					marginStart = winx - (wx + (ww * (5.f/6.f)));
+					break;
+			}
+
+			// Calculate number of points with floating precision
+			float n = width;					// Width of word in pixels
+												//					   ._.
+			n = (n / ww) * 4;					// Number of points (./   \.)
+			n += 2;								// Add two last points
+			int npoints = n;					// Convert to int
+
+			// Position of the pen to draw the lines
+			float penX = 0;
+			float penY = 0;
+
+			if (npoints >= 3) {
+				XPoint *points = xmalloc(sizeof(XPoint) * (npoints + 1));
+
+				// First point (Starts with the word bounds)
+				penX = winx;
+				switch (getSlope(winx, 0, ww)) {
+					case UNDERCURL_SLOPE_ASCENDING:
+						penY = wy + wh/2.f - marginStart;
+						break;
+					case UNDERCURL_SLOPE_TOP_CAP:
+						penY = wy;
+						break;
+					case UNDERCURL_SLOPE_DESCENDING:
+						penY = wy + marginStart;
+						break;
+					case UNDERCURL_SLOPE_BOTTOM_CAP:
+						penY = wy + wh/2.f;
+						break;
+				}
+				points[0].x = penX;
+				points[0].y = penY;
+
+				// Second point (Goes back to the absolute point coordinates)
+				switch (getSlope(winx, 1, ww)) {
+					case UNDERCURL_SLOPE_ASCENDING:
+						penX += ww * (1.f/6.f) - marginStart;
+						penY += 0;
+						break;
+					case UNDERCURL_SLOPE_TOP_CAP:
+						penX += ww * (2.f/6.f) - marginStart;
+						penY += -wh/2.f + marginStart;
+						break;
+					case UNDERCURL_SLOPE_DESCENDING:
+						penX += ww * (1.f/6.f) - marginStart;
+						penY += 0;
+						break;
+					case UNDERCURL_SLOPE_BOTTOM_CAP:
+						penX += ww * (2.f/6.f) - marginStart;
+						penY += -marginStart + wh/2.f;
+						break;
+				}
+				points[1].x = penX;
+				points[1].y = penY;
+
+				// The rest of the points
+				for (int i = 2; i < npoints; i++) {
+					switch (getSlope(winx, i, ww)) {
+						case UNDERCURL_SLOPE_ASCENDING:
+						case UNDERCURL_SLOPE_DESCENDING:
+							penX += ww * (1.f/6.f);
+							penY += 0;
+							break;
+						case UNDERCURL_SLOPE_TOP_CAP:
+							penX += ww * (2.f/6.f);
+							penY += -wh / 2.f;
+							break;
+						case UNDERCURL_SLOPE_BOTTOM_CAP:
+							penX += ww * (2.f/6.f);
+							penY += wh / 2.f;
+							break;
+					}
+					points[i].x = penX;
+					points[i].y = penY;
+				}
+
+				// End
+				float waveLength = penX - winx;
+				if (waveLength < width) { // Add a bonus point?
+					int marginEnd = width - waveLength;
+					penX += marginEnd;
+					switch(getSlope(winx, npoints, ww)) {
+						case UNDERCURL_SLOPE_ASCENDING:
+						case UNDERCURL_SLOPE_DESCENDING:
+							//penY += 0;
+							break;
+						case UNDERCURL_SLOPE_TOP_CAP:
+							penY += -marginEnd;
+							break;
+						case UNDERCURL_SLOPE_BOTTOM_CAP:
+							penY += marginEnd;
+							break;
+					}
+
+					points[npoints].x = penX;
+					points[npoints].y = penY;
+
+					npoints++;
+				} else if (waveLength > width) { // Is last point too far?
+					int marginEnd = waveLength - width;
+					points[npoints-1].x -= marginEnd;
+					switch(getSlope(winx, npoints-1, ww)) {
+						case UNDERCURL_SLOPE_TOP_CAP:
+							points[npoints-1].y += marginEnd;
+							break;
+						case UNDERCURL_SLOPE_BOTTOM_CAP:
+							points[npoints-1].y -= marginEnd;
+							break;
+						default:
+							break;
+					}
+				}
+
+				// Draw the lines
+				XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points, npoints,
+						CoordModeOrigin);
+
+				// Draw a second underline with an offset of 1 pixel
+				if ( ((win.ch / (widthThreshold/2)) % 2)) {
+					for (int i = 0; i < npoints; i++)
+						points[i].x++;
+
+					XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points,
+							npoints, CoordModeOrigin);
+				}
+
+				// Free resources
+				free(points);
+			}
+#endif
+		}
+
+		XFreeGC(xw.dpy, ugc);
 	}
 
 	if (base.mode & ATTR_STRUCK) {

--- a/x.c
+++ b/x.c
@@ -1542,7 +1542,8 @@ xmakeglyphfontspecs(XftGlyphFontSpec *specs, const Glyph *glyphs, int len, int x
 	return numspecs;
 }
 
-static int isSlopeRising (int x, int iPoint, int waveWidth)
+static int
+isSlopeRising (int x, int iPoint, int waveWidth)
 {
 	//    .     .     .     .
 	//   / \   / \   / \   / \
@@ -1558,7 +1559,8 @@ static int isSlopeRising (int x, int iPoint, int waveWidth)
 	return (absSlope % 2);
 }
 
-static int getSlope (int x, int iPoint, int waveWidth)
+static int
+getSlope (int x, int iPoint, int waveWidth)
 {
 	// Sizes: Caps are half width of slopes
 	//    1_2       1_2       1_2      1_2
@@ -1717,358 +1719,209 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 	}
 
 	/* Render underline and strikethrough. */
-	if (base.mode & ATTR_UNDERLINE) {
-		// Underline Color
-		const int widthThreshold  = 28; // +1 width every widthThreshold px of font
-		int wlw = (win.ch / widthThreshold) + 1; // Wave Line Width
-		int linecolor;
-		if ((base.ucolor[0] >= 0) &&
-			!(base.mode & ATTR_BLINK && win.mode & MODE_BLINK) &&
-			!(base.mode & ATTR_INVISIBLE)
-		) {
-			// Special color for underline
-			// Index
-			if (base.ucolor[1] < 0) {
-				linecolor = dc.col[base.ucolor[0]].pixel;
-			}
-			// RGB
-			else {
-				XColor lcolor;
-				lcolor.red = base.ucolor[0] * 257;
-				lcolor.green = base.ucolor[1] * 257;
-				lcolor.blue = base.ucolor[2] * 257;
-				lcolor.flags = DoRed | DoGreen | DoBlue;
-				XAllocColor(xw.dpy, xw.cmap, &lcolor);
-				linecolor = lcolor.pixel;
-			}
-		} else {
-			// Foreground color for underline
-			linecolor = fg->pixel;
-		}
+    if (base.mode & ATTR_UNDERLINE) {
+        // Underline Color
+        const int widthThreshold = 28; // +1 width every widthThreshold px of font
+        int wlw = (win.ch / widthThreshold) + 1; // Wave Line Width
+        int linecolor;
 
-		XGCValues ugcv = {
-			.foreground = linecolor,
-			.line_width = wlw,
-			.line_style = LineSolid,
-			.cap_style = CapNotLast
-		};
+        if ((base.ucolor[0] >= 0) && !(base.mode & ATTR_BLINK && win.mode & MODE_BLINK) && !(base.mode & ATTR_INVISIBLE)) {
+            // Special color for underline Index
+            if (base.ucolor[1] < 0) {
+                linecolor = dc.col[base.ucolor[0]].pixel;
+            }
+            // RGB
+            else {
+                XColor lcolor;
+                lcolor.red = base.ucolor[0] * 257;
+                lcolor.green = base.ucolor[1] * 257;
+                lcolor.blue = base.ucolor[2] * 257;
+                lcolor.flags = DoRed | DoGreen | DoBlue;
+                XAllocColor(xw.dpy, xw.cmap, &lcolor);
+                linecolor = lcolor.pixel;
+            }
+        } else {
+            // Foreground color for underline
+            linecolor = fg->pixel;
+        }
 
-		GC ugc = XCreateGC(xw.dpy, XftDrawDrawable(xw.draw),
-			GCForeground | GCLineWidth | GCLineStyle | GCCapStyle,
-			&ugcv);
+        XGCValues ugcv = {
+            .foreground = linecolor,
+            .line_width = wlw,
+            .line_style = LineSolid,
+            .cap_style = CapNotLast
+        };
 
-		// Underline Style
-		if (base.ustyle != 3) {
-			//XftDrawRect(xw.draw, fg, winx, winy + dc.font.ascent + 1, width, 1);
-			XFillRectangle(xw.dpy, XftDrawDrawable(xw.draw), ugc, winx,
-				winy + dc.font.ascent + 1, width, wlw);
-		} else if (base.ustyle == 3) {
-			int ww = win.cw;//width;
-			int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
-			int wx = winx;
-			int wy = winy + win.ch - dc.font.descent;
+        GC ugc = XCreateGC(xw.dpy, XftDrawDrawable(xw.draw), GCForeground | GCLineWidth | GCLineStyle | GCCapStyle, &ugcv);
 
-#if UNDERCURL_STYLE == UNDERCURL_CURLY
-			// Draw waves
-			int narcs = charlen * 2 + 1;
-			XArc *arcs = xmalloc(sizeof(XArc) * narcs);
+        // Underline Style
+        if (base.ustyle != 3) {
+            XftDrawRect(xw.draw, fg, winx, winy + win.cyo + dc.font.ascent + 1, width, 1);
+        } else if (base.ustyle == 3) {
+            int ww = win.cw;//width;
+            int wh = dc.font.descent - wlw/2 - 1;//r.height/7;
+            int wx = winx;
+            int wy = winy + win.ch - dc.font.descent;
 
-			int i = 0;
-			for (i = 0; i < charlen-1; i++) {
-				arcs[i*2] = (XArc) {
-					.x = wx + win.cw * i + ww / 4,
-					.y = wy,
-					.width = win.cw / 2,
-					.height = wh,
-					.angle1 = 0,
-					.angle2 = 180 * 64
-				};
-				arcs[i*2+1] = (XArc) {
-					.x = wx + win.cw * i + ww * 0.75,
-					.y = wy,
-					.width = win.cw/2,
-					.height = wh,
-					.angle1 = 180 * 64,
-					.angle2 = 180 * 64
-				};
-			}
-			// Last wave
-			arcs[i*2] = (XArc) {wx + ww * i + ww / 4, wy, ww / 2, wh,
-			0, 180 * 64 };
-			// Last wave tail
-			arcs[i*2+1] = (XArc) {wx + ww * i + ww * 0.75, wy, ceil(ww / 2.),
-			wh, 180 * 64, 90 * 64};
-			// First wave tail
-			i++;
-			arcs[i*2] = (XArc) {wx - ww/4 - 1, wy, ceil(ww / 2.), wh, 270 * 64,
-			90 * 64 };
+            // Cap is half of wave width
+            float capRatio = 0.5f;
 
-			XDrawArcs(xw.dpy, XftDrawDrawable(xw.draw), ugc, arcs, narcs);
+            // Make the underline corridor larger
+            wh *= 2;
 
-			free(arcs);
-#elif UNDERCURL_STYLE == UNDERCURL_SPIKY
-			// Make the underline corridor larger
-			/*
-			wy -= wh;
-			*/
-			wh *= 2;
+            // Set the angle of the slope to 45°
+            ww = wh;
+            ww *= 1 + capRatio; // Add a bit of width for the cap
 
-			// Set the angle of the slope to 45°
-			ww = wh;
+            // Position of wave is independent of word, it's absolute
+            wx = (wx / ww) * ww;
 
-			// Position of wave is independent of word, it's absolute
-			wx = (wx / (ww/2)) * (ww/2);
+            float marginStart;
+            switch(getSlope(winx, 0, ww)) {
+                case UNDERCURL_SLOPE_ASCENDING:
+                    marginStart = winx - wx;
+                    break;
+                case UNDERCURL_SLOPE_TOP_CAP:
+                    marginStart = winx - (wx + (ww * (2.f/6.f)));
+                    break;
+                case UNDERCURL_SLOPE_DESCENDING:
+                    marginStart = winx - (wx + (ww * (3.f/6.f)));
+                    break;
+                case UNDERCURL_SLOPE_BOTTOM_CAP:
+                    marginStart = winx - (wx + (ww * (5.f/6.f)));
+                    break;
+            }
 
-			int marginStart = winx - wx;
+            // Calculate number of points with floating precision
+            float n = width;					// Width of word in pixels
+                                                //					   ._.
+            n = ((n / ww) * 4) + 2;				// Number of points (./   \.) + two last points
+            int npoints = n;					// Convert to int
 
-			// Calculate number of points with floating precision
-			float n = width;					// Width of word in pixels
-			n = (n / ww) * 2;					// Number of slopes (/ or \)
-			n += 2;								// Add two last points
-			int npoints = n;					// Convert to int
+            // Position of the pen to draw the lines
+            float penX, penY = 0;
 
-			// Total length of underline
-			float waveLength = 0;
+            if (npoints >= 3) {
+                XPoint *points = xmalloc(sizeof(XPoint) * (npoints + 1));
 
-			if (npoints >= 3) {
-				// We add an aditional slot in case we use a bonus point
-				XPoint *points = xmalloc(sizeof(XPoint) * (npoints + 1));
+                // First point (Starts with the word bounds)
+                penX = winx;
+                switch (getSlope(winx, 0, ww)) {
+                    case UNDERCURL_SLOPE_ASCENDING:
+                        penY = wy + wh/2.f - marginStart;
+                        break;
+                    case UNDERCURL_SLOPE_TOP_CAP:
+                        penY = wy;
+                        break;
+                    case UNDERCURL_SLOPE_DESCENDING:
+                        penY = wy + marginStart;
+                        break;
+                    case UNDERCURL_SLOPE_BOTTOM_CAP:
+                        penY = wy + wh/2.f;
+                        break;
+                }
+                points[0].x = penX;
+                points[0].y = penY;
 
-				// First point (Starts with the word bounds)
-				points[0] = (XPoint) {
-					.x = wx + marginStart,
-					.y = (isSlopeRising(wx, 0, ww))
-						? (wy - marginStart + ww/2.f)
-						: (wy + marginStart)
-				};
+                // Second point (Goes back to the absolute point coordinates)
+                switch (getSlope(winx, 1, ww)) {
+                    case UNDERCURL_SLOPE_ASCENDING:
+                        penX += ww * (1.f/6.f) - marginStart;
+                        penY += 0;
+                        break;
+                    case UNDERCURL_SLOPE_TOP_CAP:
+                        penX += ww * (2.f/6.f) - marginStart;
+                        penY += -wh/2.f + marginStart;
+                        break;
+                    case UNDERCURL_SLOPE_DESCENDING:
+                        penX += ww * (1.f/6.f) - marginStart;
+                        penY += 0;
+                        break;
+                    case UNDERCURL_SLOPE_BOTTOM_CAP:
+                        penX += ww * (2.f/6.f) - marginStart;
+                        penY += -marginStart + wh/2.f;
+                        break;
+                }
+                points[1].x = penX;
+                points[1].y = penY;
 
-				// Second point (Goes back to the absolute point coordinates)
-				points[1] = (XPoint) {
-					.x = (ww/2.f) - marginStart,
-					.y = (isSlopeRising(wx, 1, ww))
-						? (ww/2.f - marginStart)
-						: (-ww/2.f + marginStart)
-				};
-				waveLength += (ww/2.f) - marginStart;
+                // The rest of the points
+                for (int i = 2; i < npoints; i++) {
+                    switch (getSlope(winx, i, ww)) {
+                        case UNDERCURL_SLOPE_ASCENDING:
+                        case UNDERCURL_SLOPE_DESCENDING:
+                            penX += ww * (1.f/6.f);
+                            penY += 0;
+                            break;
+                        case UNDERCURL_SLOPE_TOP_CAP:
+                            penX += ww * (2.f/6.f);
+                            penY += -wh / 2.f;
+                            break;
+                        case UNDERCURL_SLOPE_BOTTOM_CAP:
+                            penX += ww * (2.f/6.f);
+                            penY += wh / 2.f;
+                            break;
+                    }
+                    points[i].x = penX;
+                    points[i].y = penY;
+                }
 
-				// The rest of the points
-				for (int i = 2; i < npoints-1; i++) {
-					points[i] = (XPoint) {
-						.x = ww/2,
-						.y = (isSlopeRising(wx, i, ww))
-							? wh/2
-							: -wh/2
-					};
-					waveLength += ww/2;
-				}
+                // End
+                float waveLength = penX - winx;
+                if (waveLength < width) { // Add a bonus point?
+                    int marginEnd = width - waveLength;
+                    penX += marginEnd;
+                    switch(getSlope(winx, npoints, ww)) {
+                        case UNDERCURL_SLOPE_ASCENDING:
+                        case UNDERCURL_SLOPE_DESCENDING:
+                            //penY += 0;
+                            break;
+                        case UNDERCURL_SLOPE_TOP_CAP:
+                            penY += -marginEnd;
+                            break;
+                        case UNDERCURL_SLOPE_BOTTOM_CAP:
+                            penY += marginEnd;
+                            break;
+                    }
 
-				// Last point
-				points[npoints-1] = (XPoint) {
-					.x = ww/2,
-					.y = (isSlopeRising(wx, npoints-1, ww))
-						? wh/2
-						: -wh/2
-				};
-				waveLength += ww/2;
+                    points[npoints].x = penX;
+                    points[npoints].y = penY;
 
-				// End
-				if (waveLength < width) { // Add a bonus point?
-					int marginEnd = width - waveLength;
-					points[npoints] = (XPoint) {
-						.x = marginEnd,
-						.y = (isSlopeRising(wx, npoints, ww))
-							? (marginEnd)
-							: (-marginEnd)
-					};
+                    npoints++;
+                } else if (waveLength > width) { // Is last point too far?
+                    int marginEnd = waveLength - width;
+                    points[npoints-1].x -= marginEnd;
+                    switch(getSlope(winx, npoints-1, ww)) {
+                        case UNDERCURL_SLOPE_TOP_CAP:
+                            points[npoints-1].y += marginEnd;
+                            break;
+                        case UNDERCURL_SLOPE_BOTTOM_CAP:
+                            points[npoints-1].y -= marginEnd;
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
-					npoints++;
-				} else if (waveLength > width) { // Is last point too far?
-					int marginEnd = waveLength - width;
-					points[npoints-1].x -= marginEnd;
-					if (isSlopeRising(wx, npoints-1, ww))
-						points[npoints-1].y -= (marginEnd);
-					else
-						points[npoints-1].y += (marginEnd);
-				}
+                // Draw the lines
+                XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points, npoints,
+                CoordModeOrigin);
 
-				// Draw the lines
-				XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points, npoints,
-						CoordModePrevious);
+                // Draw a second underline with an offset of 1 pixel
+                if ( ((win.ch / (widthThreshold/2)) % 2)) {
+                    for (int i = 0; i < npoints; i++)
+                    points[i].x++;
 
-				// Draw a second underline with an offset of 1 pixel
-				if ( ((win.ch / (widthThreshold/2)) % 2)) {
-					points[0].x++;
+                    XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points,
+                    npoints, CoordModeOrigin);
+                }
 
-					XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points,
-							npoints, CoordModePrevious);
-				}
+                // Free resources
+                free(points);
+            }
+        }
 
-				// Free resources
-				free(points);
-			}
-#else // UNDERCURL_CAPPED
-			// Cap is half of wave width
-			float capRatio = 0.5f;
-
-			// Make the underline corridor larger
-			wh *= 2;
-
-			// Set the angle of the slope to 45°
-			ww = wh;
-			ww *= 1 + capRatio; // Add a bit of width for the cap
-
-			// Position of wave is independent of word, it's absolute
-			wx = (wx / ww) * ww;
-
-			float marginStart;
-			switch(getSlope(winx, 0, ww)) {
-				case UNDERCURL_SLOPE_ASCENDING:
-					marginStart = winx - wx;
-					break;
-				case UNDERCURL_SLOPE_TOP_CAP:
-					marginStart = winx - (wx + (ww * (2.f/6.f)));
-					break;
-				case UNDERCURL_SLOPE_DESCENDING:
-					marginStart = winx - (wx + (ww * (3.f/6.f)));
-					break;
-				case UNDERCURL_SLOPE_BOTTOM_CAP:
-					marginStart = winx - (wx + (ww * (5.f/6.f)));
-					break;
-			}
-
-			// Calculate number of points with floating precision
-			float n = width;					// Width of word in pixels
-												//					   ._.
-			n = (n / ww) * 4;					// Number of points (./   \.)
-			n += 2;								// Add two last points
-			int npoints = n;					// Convert to int
-
-			// Position of the pen to draw the lines
-			float penX = 0;
-			float penY = 0;
-
-			if (npoints >= 3) {
-				XPoint *points = xmalloc(sizeof(XPoint) * (npoints + 1));
-
-				// First point (Starts with the word bounds)
-				penX = winx;
-				switch (getSlope(winx, 0, ww)) {
-					case UNDERCURL_SLOPE_ASCENDING:
-						penY = wy + wh/2.f - marginStart;
-						break;
-					case UNDERCURL_SLOPE_TOP_CAP:
-						penY = wy;
-						break;
-					case UNDERCURL_SLOPE_DESCENDING:
-						penY = wy + marginStart;
-						break;
-					case UNDERCURL_SLOPE_BOTTOM_CAP:
-						penY = wy + wh/2.f;
-						break;
-				}
-				points[0].x = penX;
-				points[0].y = penY;
-
-				// Second point (Goes back to the absolute point coordinates)
-				switch (getSlope(winx, 1, ww)) {
-					case UNDERCURL_SLOPE_ASCENDING:
-						penX += ww * (1.f/6.f) - marginStart;
-						penY += 0;
-						break;
-					case UNDERCURL_SLOPE_TOP_CAP:
-						penX += ww * (2.f/6.f) - marginStart;
-						penY += -wh/2.f + marginStart;
-						break;
-					case UNDERCURL_SLOPE_DESCENDING:
-						penX += ww * (1.f/6.f) - marginStart;
-						penY += 0;
-						break;
-					case UNDERCURL_SLOPE_BOTTOM_CAP:
-						penX += ww * (2.f/6.f) - marginStart;
-						penY += -marginStart + wh/2.f;
-						break;
-				}
-				points[1].x = penX;
-				points[1].y = penY;
-
-				// The rest of the points
-				for (int i = 2; i < npoints; i++) {
-					switch (getSlope(winx, i, ww)) {
-						case UNDERCURL_SLOPE_ASCENDING:
-						case UNDERCURL_SLOPE_DESCENDING:
-							penX += ww * (1.f/6.f);
-							penY += 0;
-							break;
-						case UNDERCURL_SLOPE_TOP_CAP:
-							penX += ww * (2.f/6.f);
-							penY += -wh / 2.f;
-							break;
-						case UNDERCURL_SLOPE_BOTTOM_CAP:
-							penX += ww * (2.f/6.f);
-							penY += wh / 2.f;
-							break;
-					}
-					points[i].x = penX;
-					points[i].y = penY;
-				}
-
-				// End
-				float waveLength = penX - winx;
-				if (waveLength < width) { // Add a bonus point?
-					int marginEnd = width - waveLength;
-					penX += marginEnd;
-					switch(getSlope(winx, npoints, ww)) {
-						case UNDERCURL_SLOPE_ASCENDING:
-						case UNDERCURL_SLOPE_DESCENDING:
-							//penY += 0;
-							break;
-						case UNDERCURL_SLOPE_TOP_CAP:
-							penY += -marginEnd;
-							break;
-						case UNDERCURL_SLOPE_BOTTOM_CAP:
-							penY += marginEnd;
-							break;
-					}
-
-					points[npoints].x = penX;
-					points[npoints].y = penY;
-
-					npoints++;
-				} else if (waveLength > width) { // Is last point too far?
-					int marginEnd = waveLength - width;
-					points[npoints-1].x -= marginEnd;
-					switch(getSlope(winx, npoints-1, ww)) {
-						case UNDERCURL_SLOPE_TOP_CAP:
-							points[npoints-1].y += marginEnd;
-							break;
-						case UNDERCURL_SLOPE_BOTTOM_CAP:
-							points[npoints-1].y -= marginEnd;
-							break;
-						default:
-							break;
-					}
-				}
-
-				// Draw the lines
-				XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points, npoints,
-						CoordModeOrigin);
-
-				// Draw a second underline with an offset of 1 pixel
-				if ( ((win.ch / (widthThreshold/2)) % 2)) {
-					for (int i = 0; i < npoints; i++)
-						points[i].x++;
-
-					XDrawLines(xw.dpy, XftDrawDrawable(xw.draw), ugc, points,
-							npoints, CoordModeOrigin);
-				}
-
-				// Free resources
-				free(points);
-			}
-#endif
-		}
-
-		XFreeGC(xw.dpy, ugc);
+        XFreeGC(xw.dpy, ugc);
 	}
 
 	if (base.mode & ATTR_STRUCK) {

--- a/xst.c
+++ b/xst.c
@@ -125,6 +125,7 @@ xrdb_load(void)
 
 		XRESOURCE_LOAD_INTEGER("depth", opt_depth);
 		XRESOURCE_LOAD_INTEGER("undercurl_shape", undercurl_shape);
+		XRESOURCE_LOAD_INTEGER("undercurl_thickness_threshold", undercurl_thickness_threshold);
 	}
 	XFlush(dpy);
 }

--- a/xst.c
+++ b/xst.c
@@ -124,6 +124,7 @@ xrdb_load(void)
 		XRESOURCE_LOAD_INTEGER("boxdraw_braille", boxdraw_braille);
 
 		XRESOURCE_LOAD_INTEGER("depth", opt_depth);
+		XRESOURCE_LOAD_INTEGER("undercurl_shape", undercurl_shape);
 	}
 	XFlush(dpy);
 }


### PR DESCRIPTION
See #136 for more info on what undercurls are. I've patched everything except for one conflict, xst compiles fine, however I still get underlines instead of undercurls.

That one conflict was [this line](https://gist.github.com/RaafatTurki/a32d8b5636fa7e2e17bc1505e0bb3d4b#file-st-undercurl-0-8-4-20210822-diff-L250) which removes an [XftDrawRect](https://github.com/gnotclub/xst/blob/d35241209e47ea40ba0ffdc63b04b7134295b76d/x.c#L1668) function call and replaces it with the actual implementation of the undercurls + a fallback to underlines

Here's a comparison of that function call 
### patch
```c
XftDrawRect(xw.draw, fg, winx, winy + dc.font.ascent + 1, width, 1);
```
### xst
```c
XftDrawRect(xw.draw, fg, winx, winy + win.cyo + dc.font.ascent + 1, width, 1);
```

They only differ in the addition of `win.cyo`, I have no idea what xst patch introduced this parameter, its significance nor how it should be used within the newly patched code.

Any hint would be highly appreciated.