### PR TITLE
Allow overriding colors in the 256 color space

### DIFF
--- a/x.c
+++ b/x.c
@@ -785,7 +785,7 @@ xloadcolor(int i, const char *name, Color *ncolor)
 	XRenderColor color = { .alpha = 0xffff };
 
 	if (!name) {
-		if (BETWEEN(i, 16, 255)) { /* 256 color */
+		if (BETWEEN(i, 16, 255) && !colorname[i]) { /* 256 color */
 			if (i < 6*6*6+16) { /* same colors as xterm */
 				color.red   = sixd_to_16bit( ((i-16)/36)%6 );
 				color.green = sixd_to_16bit( ((i-16)/6) %6 );


### PR DESCRIPTION
Same as #38 but check `i` is in range first before checking the `colorname` (to ensure index of `colorname` doesn't go off the end of the array).