### PR TITLE
fix sigchld() for externalpipe

### DIFF
--- a/st.c
+++ b/st.c
@@ -735,9 +735,14 @@ sigchld(int a)
 	if ((p = waitpid(pid, &stat, WNOHANG)) < 0)
 		die("waiting for pid %hd failed: %s\n", pid, strerror(errno));
 
-	if (pid != p)
-		return;
+	if (pid != p) {
+		if (p == 0 && wait(&stat) < 0)
+			die("wait: %s\n", strerror(errno));
 
+		/* reinstall sigchld handler */
+		signal(SIGCHLD, sigchld);
+		return;
+	}
 	if (WIFEXITED(stat) && WEXITSTATUS(stat))
 		die("child exited with status %d\n", WEXITSTATUS(stat));
 	else if (WIFSIGNALED(stat))


### PR DESCRIPTION
Whenever a child process finishes its task, it turns into a zombie instead of getting killed.

sigchld() is patched the same way upstream:
https://st.suckless.org/patches/externalpipe/st-externalpipe-0.8.4.diff