### PR TITLE
[ci] pin a platform version

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-latest` doesn't appear to have x libraries