### PR TITLE
Rename pkgconfig to pkg-config in nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,6 @@ let
 in pkgs.mkShell {
   buildInputs =
     (with pkgs; [
-      stdenv pkgconfig xorg.libX11 ncurses xorg.libXft harfbuzz
+      stdenv pkg-config xorg.libX11 ncurses xorg.libXft harfbuzz
     ]);
 }


### PR DESCRIPTION
Recently pkgconfig was renamed to pkg-config in the nix repos.

Currently, while trying to eval shell.nix, I get this error:

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/chi01x4fh8hx7wwh0rqd7m1c8583iyhv-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'

         at /nix/store/chi01x4fh8hx7wwh0rqd7m1c8583iyhv-source/pkgs/stdenv/generic/make-derivation.nix:395:7:

          394|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          395|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          396|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       error: 'pkgconfig' has been renamed to/replaced by 'pkg-config'
```

This PR fixes this issue