### PR TITLE
Fix fallback fonts' handling and building with `-flto=auto` (Fixes: #159, Fixes: #144, Fixes: #165)

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
     - name: make
       run: make
     - name: make install
-      run: sudo env PREFIX=/usr/ make install
+      run: sudo make PREFIX=/usr/ install
     - name: test deps
       run: sudo apt-get install -y xvfb
     - name: smoke test build

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,5 +21,9 @@ jobs:
       run: sudo apt-get install -y xvfb
     - name: smoke test build
       run: xvfb-run ./xst bash -c exit
+    - name: check installed file
+      run: ls -la /usr/bin/xst || true
+    - name: check installed file
+      run: ls -la /usr/local/bin/xst || true
     - name: smoke test install
       run: xvfb-run xst bash -c exit

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,9 +21,5 @@ jobs:
       run: sudo apt-get install -y xvfb
     - name: smoke test build
       run: xvfb-run ./xst bash -c exit
-    - name: check installed file
-      run: ls -la /usr/bin/xst || true
-    - name: check installed file
-      run: ls -la /usr/local/bin/xst || true
     - name: smoke test install
       run: xvfb-run xst bash -c exit

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -22,4 +22,4 @@ jobs:
     - name: smoke test build
       run: xvfb-run ./xst bash -c exit
     - name: smoke test install
-      run: xvfb-run xst bash -c exit
+      run: sync ; sleep 0.1 ; xvfb-run xst bash -c exit

--- a/config.def.h
+++ b/config.def.h
@@ -6,7 +6,6 @@
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
 static char *font = "Liberation Mono:pixelsize=12:antialias=true:autohint=true";
-// Initial static values
 static char *font2[] = {
 /*	"Inconsolata for Powerline:pixelsize=12:antialias=true:autohint=true", */
 /*	"Hack Nerd Font Mono:pixelsize=11:antialias=true:autohint=true", */

--- a/config.def.h
+++ b/config.def.h
@@ -6,7 +6,8 @@
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
 static char *font = "Liberation Mono:pixelsize=12:antialias=true:autohint=true";
-static char *font2[] = {
+// Initial static values
+static char *default_fallback_fonts[] = {
 /*	"Inconsolata for Powerline:pixelsize=12:antialias=true:autohint=true", */
 /*	"Hack Nerd Font Mono:pixelsize=11:antialias=true:autohint=true", */
 };

--- a/config.def.h
+++ b/config.def.h
@@ -7,7 +7,7 @@
  */
 static char *font = "Liberation Mono:pixelsize=12:antialias=true:autohint=true";
 // Initial static values
-static char *default_fallback_fonts[] = {
+static char *font2[] = {
 /*	"Inconsolata for Powerline:pixelsize=12:antialias=true:autohint=true", */
 /*	"Hack Nerd Font Mono:pixelsize=11:antialias=true:autohint=true", */
 };

--- a/x.c
+++ b/x.c
@@ -337,9 +337,7 @@ zoomabs(const Arg *arg)
 {
 	xunloadfonts();
 	xloadfonts(getusedfont(), arg->f);
-	fonts_count--;
 	xloadsparefonts();
-	fonts_count++;
 	cresize(0, 0);
 	redraw();
 	xhints();

--- a/x.c
+++ b/x.c
@@ -77,8 +77,8 @@ static void ttysend(const Arg *);
 /* Calculate count of spare fonts */
 static int fonts_count = 0;
 
-// Declare font2 as a dynamic array
-static char **font2 = NULL;
+// Declare fallback_fonts as a dynamic array
+static char **fallback_fonts = NULL;
 
 /* XEMBED messages */
 #define XEMBED_FOCUS_IN  4
@@ -1160,19 +1160,19 @@ xinitsparefonts(void)
 	if (fonts_count) return;
 
 	// Allocate memory for initial fonts
-	int initial_count = sizeof(default_fallback_fonts) / sizeof(default_fallback_fonts[0]);
-	font2 = malloc((initial_count + 1) * sizeof(char *));
-	if (!font2) {
+	int initial_count = sizeof(font2) / sizeof(font2[0]);
+	fallback_fonts = malloc((initial_count + 1) * sizeof(char *));
+	if (!fallback_fonts) {
 		die("Error initializing fallback fonts!\n");
 	}
 
-	// Copy the initial fonts to font2
+	// Copy the initial fonts to fallback_fonts
 	for (int i = 0; i < initial_count; i++) {
-		font2[i] = default_fallback_fonts[i];
+		fallback_fonts[i] = font2[i];
 	}
 
 	fonts_count = initial_count;
-	font2[fonts_count] = NULL;  // Null-terminate the array
+	fallback_fonts[fonts_count] = NULL;  // Null-terminate the array
 }
 
 void
@@ -1194,7 +1194,7 @@ xloadsparefonts(void)
 		frc = xrealloc(frc, frccap * sizeof(Fontcache));
 	}
 
-	for (fp = font2; fp < font2 + fonts_count && *fp != NULL; ++fp) {
+	for (fp = fallback_fonts; fp < fallback_fonts + fonts_count && *fp != NULL; ++fp) {
 
 		if (**fp == '-')
 			pattern = XftXlfdParse(*fp, False, False);

--- a/xst.c
+++ b/xst.c
@@ -63,20 +63,36 @@ xrdb_load(void)
 		}
 
 		XRESOURCE_LOAD_META("font_fallback") {
-			int count = 0, endchar = fonts_count = sizeof(font2) / sizeof(*font2);
-			for (int i = 0; ret.addr[i]; i++) if (ret.addr[i] == ',') count++;
-			if (count > 0)
-			{
-				for (int i = 0; i <= count; i++)
-				{
-					if (i == 0) font2[endchar + i] = strtok(ret.addr, ",");
-					else				font2[endchar + i] = strtok(NULL, ",");
-					fonts_count++;
+			int count = 0;
+			for (int i = 0; ret.addr[i]; i++) {
+				if (ret.addr[i] == ',') count++;
+			}
+
+			if (count > 0) {
+				// Reallocate font2 to fit additional fonts from Xresources
+				font2 = realloc(font2, (fonts_count + count + 2) * sizeof(char *));
+				if (!font2) {
+					printf("ERROR: can't load fonts from 'st.font_fallback' !\n");
 				}
-				font2[endchar + count + 1] = '\0';
+
+				for (int i = 0; i <= count; i++) {
+					if (i == 0)
+						font2[fonts_count + i] = strtok(ret.addr, ",");
+					else
+						font2[fonts_count + i] = strtok(NULL, ",");
+					printf(" :: XRDB: adding fallback font: %s \n", font2[fonts_count + i]);
+				}
+
+				fonts_count += count + 1;
+				font2[fonts_count] = NULL;  // Null-terminate
 			} else if (ret.addr) {
-				font2[endchar] = ret.addr;
-				fonts_count++;
+				font2 = realloc(font2, (fonts_count + 2) * sizeof(char *));
+				if (!font2) {
+					// Handle allocation failure
+				}
+
+				font2[fonts_count++] = ret.addr;
+				font2[fonts_count] = NULL;  // Null-terminate
 			}
 		}
 

--- a/xst.c
+++ b/xst.c
@@ -157,6 +157,7 @@ reload(int sig)
 	if (sig == -1) {
 		return;
 	}
+	printf(" :: XST:: reloading config...\n");
 
 	xrdb_load();
 
@@ -164,11 +165,14 @@ reload(int sig)
 	xloadcols();
 	xunloadfonts();
 	xloadfonts(getusedfont(), 0);
+	xinitsparefonts();
+	xloadsparefonts();
 	xsetcursor(cursorshape);
 
 	/* pretend the window just got resized */
 	cresize(win.w, win.h);
 	redraw();
+	xhints();
 	/* triggers re-render if we're visible. */
 	ttywrite("\033[O", 3, 1);
 }

--- a/xst.c
+++ b/xst.c
@@ -88,7 +88,7 @@ xrdb_load(void)
 			} else if (ret.addr) {
 				fallback_fonts = realloc(fallback_fonts, (fonts_count + 2) * sizeof(char *));
 				if (!fallback_fonts) {
-					// Handle allocation failure
+					printf("ERROR: can't load fonts from 'st.font_fallback' !\n");
 				}
 
 				fallback_fonts[fonts_count++] = ret.addr;

--- a/xst.c
+++ b/xst.c
@@ -73,6 +73,7 @@ xrdb_load(void)
 				fallback_fonts = realloc(fallback_fonts, (fonts_count + count + 2) * sizeof(char *));
 				if (!fallback_fonts) {
 					printf("ERROR: can't load fonts from 'st.font_fallback' !\n");
+					return;
 				}
 
 				for (int i = 0; i <= count; i++) {
@@ -89,6 +90,7 @@ xrdb_load(void)
 				fallback_fonts = realloc(fallback_fonts, (fonts_count + 2) * sizeof(char *));
 				if (!fallback_fonts) {
 					printf("ERROR: can't load fonts from 'st.font_fallback' !\n");
+					return;
 				}
 
 				fallback_fonts[fonts_count++] = ret.addr;

--- a/xst.c
+++ b/xst.c
@@ -69,30 +69,30 @@ xrdb_load(void)
 			}
 
 			if (count > 0) {
-				// Reallocate font2 to fit additional fonts from Xresources
-				font2 = realloc(font2, (fonts_count + count + 2) * sizeof(char *));
-				if (!font2) {
+				// Reallocate fallback_fonts to fit additional fonts from Xresources
+				fallback_fonts = realloc(fallback_fonts, (fonts_count + count + 2) * sizeof(char *));
+				if (!fallback_fonts) {
 					printf("ERROR: can't load fonts from 'st.font_fallback' !\n");
 				}
 
 				for (int i = 0; i <= count; i++) {
 					if (i == 0)
-						font2[fonts_count + i] = strtok(ret.addr, ",");
+						fallback_fonts[fonts_count + i] = strtok(ret.addr, ",");
 					else
-						font2[fonts_count + i] = strtok(NULL, ",");
-					printf(" :: XRDB: adding fallback font: %s \n", font2[fonts_count + i]);
+						fallback_fonts[fonts_count + i] = strtok(NULL, ",");
+					printf(" :: XRDB: adding fallback font: %s \n", fallback_fonts[fonts_count + i]);
 				}
 
 				fonts_count += count + 1;
-				font2[fonts_count] = NULL;  // Null-terminate
+				fallback_fonts[fonts_count] = NULL;  // Null-terminate
 			} else if (ret.addr) {
-				font2 = realloc(font2, (fonts_count + 2) * sizeof(char *));
-				if (!font2) {
+				fallback_fonts = realloc(fallback_fonts, (fonts_count + 2) * sizeof(char *));
+				if (!fallback_fonts) {
 					// Handle allocation failure
 				}
 
-				font2[fonts_count++] = ret.addr;
-				font2[fonts_count] = NULL;  // Null-terminate
+				fallback_fonts[fonts_count++] = ret.addr;
+				fallback_fonts[fonts_count] = NULL;  // Null-terminate
 			}
 		}
 


### PR DESCRIPTION
(pls squash when merging with msg: `fix fallback fonts' handling`)


Fixes: #159, Fixes: #144, Fixes: #165